### PR TITLE
Consolidate homepage hobbies

### DIFF
--- a/src/data/siteContent.ts
+++ b/src/data/siteContent.ts
@@ -201,20 +201,22 @@ export const facts: RichText[] = [
 export const personal = {
   origin: "I grew up in Taipei, Taiwan (Mandarin name: 林彥彤 / Yan-Tong Lin).",
   hobbies: [
-    "Poker",
-    "Competitive multiplayer games",
-    "Health & fitness",
-    "Guitar & piano",
-  ],
-  hobbyLinks: [
-    {
-      href: "https://youtu.be/XmpmadFYGOk",
-      label: 'My "Fight" acoustic guitar cover',
-    },
-    {
-      href: "https://youtu.be/MSYaon4zNsc?si=ac7TzA_bLDmVUMfR",
-      label: "Hosted by Antalpha Hacker House during ETH CC in Paris",
-    },
+    ["Poker; competitive multiplayer games; health & fitness."],
+    [
+      "Guitar & piano: ",
+      {
+        href: "https://youtu.be/XmpmadFYGOk",
+        text: '"Fight" acoustic guitar cover',
+      },
+      ".",
+    ],
+    [
+      {
+        href: "https://youtu.be/MSYaon4zNsc?si=ac7TzA_bLDmVUMfR",
+        text: "ETH CC Paris hacker house",
+      },
+      ".",
+    ],
   ],
 };
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -51,8 +51,7 @@ const frontmatter = pageMeta.home;
 
   <h3>Hobbies</h3>
   <ul>
-    {personal.hobbies.map((hobby) => <li>{hobby}</li>)}
-    {personal.hobbyLinks.map((link) => <li><a href={link.href}>{link.label}</a></li>)}
+    {personal.hobbies.map((hobby) => <li><RichText parts={hobby} /></li>)}
   </ul>
 
   <hr />


### PR DESCRIPTION
## Summary
- consolidate homepage hobbies into fewer lines
- keep the "Fight" guitar cover linked from the music line
- render hobbies from the shared site content source

## Validation
- npm run build
- git diff --check