### PR TITLE
Add concise reusable about copy

### DIFF
--- a/src/data/siteContent.ts
+++ b/src/data/siteContent.ts
@@ -117,6 +117,11 @@ export const socialLinks = [links.github, links.linkedin, links.resume, links.x]
 
 export const profile = {
   name: siteMeta.name,
+  about: [
+    [
+      "I design and build algorithms and infrastructure for recursive self-improvement, especially around generative models, reinforcement learning, and software-engineering agents. My taste is simple: make things as simple as possible, but not simpler; quotient out accidental detail, preserve the invariant, then build from there.",
+    ],
+  ],
   photo: {
     src: "/img/profile.jpg",
     alt: siteMeta.name,

--- a/src/data/siteContent.ts
+++ b/src/data/siteContent.ts
@@ -119,7 +119,7 @@ export const profile = {
   name: siteMeta.name,
   about: [
     [
-      "I design and build algorithms and infrastructure for recursive self-improvement, especially around generative models, reinforcement learning, and software-engineering agents. My taste is simple: make things as simple as possible, but not simpler; quotient out accidental detail, preserve the invariant, then build from there.",
+      "I design and build algorithms and infrastructure for recursive self-improvement, especially around generative models, reinforcement learning, and software-engineering agents. I try to approach research, engineering, business, and prioritization the same way: make things as simple as possible, but not simpler; quotient out accidental detail, preserve the invariant, then build from there.",
     ],
   ],
   photo: {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,6 +19,7 @@ const frontmatter = pageMeta.home;
   </figure>
 
   <h2>About Me</h2>
+  {profile.about.map((paragraph) => <p><RichText parts={paragraph} /></p>)}
 
   <h2>{currentWork.heading}</h2>
   {currentWork.paragraphs.map((paragraph) => <p><RichText parts={paragraph} /></p>)}


### PR DESCRIPTION
## Summary
- add a concise About Me paragraph to the homepage
- source the paragraph from shared site content
- keep Current Work as the detailed role-specific section

## Validation
- npm run build
- git diff --check
- verified localhost renders the paragraph before Current Work