### PR TITLE
Use full National Chiao Tung University name

### DIFF
--- a/src/data/experienceTimeline.ts
+++ b/src/data/experienceTimeline.ts
@@ -220,10 +220,10 @@ export const experienceTimeline: TimelineItem[] = [
     id: "nycu",
     kind: "education",
     title: "B.S. Computer Science and Applied Mathematics",
-    organization: "National Yang Ming Chiao Tung University",
+    organization: "National Chiao Tung University",
     location: "Hsinchu, Taiwan",
     period: "Sep 2018 - Jun 2021",
-    shortLabel: "NYCU",
+    shortLabel: "National Chiao Tung University",
     homepageSummary:
       "CS and applied math; Presidential Award top 5%; A+ in proof-heavy theory courses.",
     summary: [
@@ -236,7 +236,7 @@ export const experienceTimeline: TimelineItem[] = [
     ],
     image: {
       src: "/img/experience/nycu.png",
-      alt: "National Yang Ming Chiao Tung University logo",
+      alt: "National Chiao Tung University logo",
     },
   },
   {


### PR DESCRIPTION
## Summary
- replace the NYCU abbreviation and merged-university name with National Chiao Tung University in the shared experience timeline data
- keep homepage and experience page education references generated from the same timeline source

## Validation
- npm run build
- git diff --check
- searched source and built output for old and new education names