### PR TITLE
Track last updated dates per page

### DIFF
--- a/src/data/siteContent.ts
+++ b/src/data/siteContent.ts
@@ -42,7 +42,6 @@ export type PageMeta = {
 export const siteMeta = {
   author: "Maxwill Lin",
   description: "Maxwill's personal website.",
-  latestContentUpdate: "2026-06-25",
   name: "Maxwill Lin",
   technicalDescription:
     "Technical writing, notes, and project documentation by Maxwill Lin.",
@@ -84,47 +83,58 @@ export const links = {
   primeRl: { href: `${pageHrefs.oss}#prime-rl`, label: "Prime-RL" },
 };
 
+const pageLastUpdated = {
+  coursework: "2026-06-18",
+  experience: "2026-06-18",
+  home: "2026-06-23",
+  oss: "2026-06-25",
+  projects: "2026-06-17",
+  socials: "2026-06-18",
+  writing: "2026-06-18",
+  writingTags: "2026-06-18",
+} as const;
+
 export const pageMeta = {
   coursework: {
     title: links.coursework.label,
-    lastUpdated: siteMeta.latestContentUpdate,
+    lastUpdated: pageLastUpdated.coursework,
     tags: ["writing", "coursework"],
   },
   home: {
     title: siteMeta.name,
     heading: false,
-    lastUpdated: siteMeta.latestContentUpdate,
+    lastUpdated: pageLastUpdated.home,
     tags: ["home"],
   },
   experience: {
     title: "Experience & Education",
-    lastUpdated: siteMeta.latestContentUpdate,
+    lastUpdated: pageLastUpdated.experience,
     tags: ["experience", "education"],
   },
   oss: {
     title: "Open Source Contributions",
-    lastUpdated: siteMeta.latestContentUpdate,
+    lastUpdated: pageLastUpdated.oss,
     tags: ["engineering", "oss"],
   },
   projects: {
     title: links.projects.label,
-    lastUpdated: siteMeta.latestContentUpdate,
+    lastUpdated: pageLastUpdated.projects,
     tags: ["engineering"],
   },
   socials: {
     title: links.socials.label,
-    lastUpdated: siteMeta.latestContentUpdate,
+    lastUpdated: pageLastUpdated.socials,
     tags: ["socials", "identity"],
   },
   writing: {
     title: links.writing.label,
-    lastUpdated: siteMeta.latestContentUpdate,
+    lastUpdated: pageLastUpdated.writing,
     tags: ["writing"],
   },
   writingTags: {
     title: "Writing Tags",
     heading: links.writingTags.label,
-    lastUpdated: siteMeta.latestContentUpdate,
+    lastUpdated: pageLastUpdated.writingTags,
     tags: ["writing", "tags"],
   },
 };

--- a/src/data/writingIndex.ts
+++ b/src/data/writingIndex.ts
@@ -190,6 +190,19 @@ const sortEntries = (entries: WritingEntry[]) =>
     return left.title.localeCompare(right.title);
   });
 
+export const latestLastUpdated = (entries: Array<{ lastUpdated?: string }>) =>
+  entries.reduce<string | undefined>((latest, entry) => {
+    if (!entry.lastUpdated) {
+      return latest;
+    }
+
+    if (!latest || entry.lastUpdated > latest) {
+      return entry.lastUpdated;
+    }
+
+    return latest;
+  }, undefined);
+
 const selectedMarkdownEntries = Object.entries(internalPageModules)
   .map(([path, mod]) => {
     const frontmatter = mod.frontmatter ?? {};

--- a/src/pages/writing.astro
+++ b/src/pages/writing.astro
@@ -3,13 +3,17 @@ import ArticleLayout from "../layouts/ArticleLayout.astro";
 import { links, pageMeta } from "../data/siteContent";
 import {
   isTopicTag,
+  latestLastUpdated,
   primaryTagFacets,
   tagFacets,
   writingEntries,
 } from "../data/writingIndex";
 import { formatDisplayDate } from "../utils/dates";
 
-const frontmatter = pageMeta.writing;
+const frontmatter = {
+  ...pageMeta.writing,
+  lastUpdated: latestLastUpdated(writingEntries) ?? pageMeta.writing.lastUpdated,
+};
 ---
 
 <ArticleLayout frontmatter={frontmatter}>

--- a/src/pages/writing/tags/[tag].astro
+++ b/src/pages/writing/tags/[tag].astro
@@ -1,7 +1,7 @@
 ---
 import ArticleLayout from "../../../layouts/ArticleLayout.astro";
 import { links, pageMeta } from "../../../data/siteContent";
-import { tagFacets } from "../../../data/writingIndex";
+import { latestLastUpdated, tagFacets } from "../../../data/writingIndex";
 import { formatDisplayDate } from "../../../utils/dates";
 
 export function getStaticPaths() {
@@ -16,6 +16,7 @@ const frontmatter = {
   ...pageMeta.writing,
   title: `${pageMeta.writing.title}: ${tag.label}`,
   heading: tag.label,
+  lastUpdated: latestLastUpdated(tag.entries) ?? pageMeta.writing.lastUpdated,
   tags: ["writing", tag.label],
 };
 ---

--- a/src/pages/writing/tags/index.astro
+++ b/src/pages/writing/tags/index.astro
@@ -1,9 +1,12 @@
 ---
 import ArticleLayout from "../../../layouts/ArticleLayout.astro";
 import { links, pageMeta } from "../../../data/siteContent";
-import { tagFacets } from "../../../data/writingIndex";
+import { latestLastUpdated, tagFacets, writingEntries } from "../../../data/writingIndex";
 
-const frontmatter = pageMeta.writingTags;
+const frontmatter = {
+  ...pageMeta.writingTags,
+  lastUpdated: latestLastUpdated(writingEntries) ?? pageMeta.writingTags.lastUpdated,
+};
 ---
 
 <ArticleLayout frontmatter={frontmatter}>


### PR DESCRIPTION
## Summary
- Replace the shared website-wide updated date with explicit page-level dates
- Derive generated writing index and tag dates from the entries they list
- Keep article modified metadata aligned with each page timestamp

## Verification
- npm run build
- git diff --check
- rendered date checks across representative pages
- sanitized this website PR description to avoid upstream cross-reference noise

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-page update dates across the site, so page metadata can reflect the most recent content changes more accurately.
  * Writing pages and tag pages now show a dynamically computed “last updated” value based on their content.

* **Bug Fixes**
  * Improved update-date handling for writing listings and tag pages by falling back to existing page dates when no newer content date is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->